### PR TITLE
Update username to Linkle and Fortnite username to Linkle_69

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -130,7 +130,7 @@ if (response.ok) {
         <link rel='icon' type='image/png' href='favicon-64.png' sizes='64x64' />
         <link rel='icon' type='image/png' href='favicon-96.png' sizes='96x96' />
         <link rel='icon' type='image/png' href='favicon-192.png' sizes='192x192' />
-        <title>Link</title>
+        <title>Linkle</title>
         <meta name='og:title' content={displayName} />
         <meta name='og:description' content='My own silly profile website lol' />
         <meta name='description' content='My own silly profile website lol' />
@@ -332,9 +332,9 @@ if (response.ok) {
                 </p>
                 <p>
                     Fortnite Username: <a
-                        href='https://fortnitetracker.com/profile/all/LinkDiscord'
+                        href='https://fortnitetracker.com/profile/all/Linkle_69'
                         target='_blank'
-                        rel='noopener'>LinkDiscord</a
+                        rel='noopener'>Linkle_69</a
                     >
                 </p>
                 <p>


### PR DESCRIPTION
This pull request makes minor updates to the `src/pages/index.astro` file to update the title and a Fortnite username reference.

* **Title Update**:
  - Changed the `<title>` tag from "Link" to "Linkle". (`[src/pages/index.astroL133-R133](diffhunk://#diff-95d291e9ce4c8739cc7e65ff7bf0838dd5294cf39ab787ba51a42d08fb2df663L133-R133)`)

* **Fortnite Username Update**:
  - Updated the Fortnite username link and display text from "LinkDiscord" to "Linkle_69". (`[src/pages/index.astroL335-R337](diffhunk://#diff-95d291e9ce4c8739cc7e65ff7bf0838dd5294cf39ab787ba51a42d08fb2df663L335-R337)`)